### PR TITLE
parameter counting

### DIFF
--- a/tests/test_parameter_counting.py
+++ b/tests/test_parameter_counting.py
@@ -22,6 +22,11 @@ for n in range(5):
     graphs.append(g)
 
 
+# Before a model has been pre_fit, all PerElementParameters should have 0
+# relevant and countable values. After pre_fitting, the PerElementParameter
+# values corresponding to elements seen in the pre-fit data should be counted.
+
+
 def test_fixed():
     model = FixedOffset(H=1.0, C=2.0)
 


### PR DESCRIPTION
Add tests to check that we are correctly counting the number of parameters a model has.

Before a model has been `pre_fit`, all `PerElementParameters` should have 0 relevant and countable values.

After `pre_fit`ting, the `PerElementParameter` values corresponding to elements seen in the pre-fit data should be counted.