### PR TITLE
Cache python environment to reduce CI time

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,31 +39,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache dependencies
+      # Cacheing the python environment. This is different to just cacheing the
+      # pip wheels, as we save on the installation time of large packages such
+      # as torch.
         uses: actions/cache@v4.0.2
         id: cache
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install graph-pes and required dependencies
-        # if: steps.cache.outputs.cache-hit != 'true'
-        # run: |
-        #   pip install ".[test]"
-        #   pip cache purge
-        # else:
+      # Install graph-pes and update any dependencies that are not up to date in
+      # the cached environment. We use the --upgrade-strategy eager flag to get
+      # the latest version of the dependencies.
         run: pip install --upgrade --upgrade-strategy eager ".[test]"
       - name: Useful info
         run: pip freeze
-      # - name: Run pytest checks
-      # - name: update pip
-      #   run: pip install --upgrade pip
-      # - name: Install graph-pes
-      #   run: pip install ".[test]"
-      # - name: Install pyright
-      #   run: pip install pyright
-      # - name: Useful info
-      #   run: pip freeze
       - name: Run pyright
-        run: pyright --verbose
+        run: pyright
       - name: Run tests
         run: pytest --cov --cov-report xml
       - name: Upload coverage reports to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov"]
+test = ["pytest", "pytest-cov", "pyright"]
 dev = ["notebook", "ruff", "bumpver", "pyright"]
 doc = [
     "sphinx",


### PR DESCRIPTION
Adding cacheing behaviour for python on GitHub actions servers. 

Expected behaviour:
 - First time: cache python environment after `pip install .`
 - Then: use cache, but install `graph-pes` over the top. Use `--upgrade` and `--upgrade-strategy eager` to make sure the environment is always updated if any dependencies are updated.
 - Cache is updated when `pyproject.toml` changes.

Time reductions:
 - Before: ~ 4m15 per CI test run
 - Now: ~ 2m40 per CI test run
 
