### PR TITLE
align `TensorNet` with `TorchMD` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Changed the implementation of `TensorNet` to exactly match that in `TorchMD`.
+
+### Fixed
+
+Fixed test warnings.
+
 ## [0.0.14] - 2024-12-12
 
 ### Added

--- a/src/graph_pes/atomic_graph.py
+++ b/src/graph_pes/atomic_graph.py
@@ -972,7 +972,7 @@ def trim_edges(graph: AtomicGraph, cutoff: float) -> AtomicGraph:
     """
 
     existing_cutoff = graph.cutoff
-    if existing_cutoff < cutoff:
+    if existing_cutoff + 1e-5 < cutoff:
         warnings.warn(
             f"Graph already has a cutoff of {existing_cutoff} which is "
             f"less than the requested cutoff of {cutoff}.",

--- a/src/graph_pes/models/components/distances.py
+++ b/src/graph_pes/models/components/distances.py
@@ -70,7 +70,9 @@ class DistanceExpansion(torch.nn.Module, ABC):
         )
 
 
-def get_distance_expansion(name: str) -> type[DistanceExpansion]:
+def get_distance_expansion(
+    thing: str | type[DistanceExpansion],
+) -> type[DistanceExpansion]:
     """
     Get a distance expansion class by it's name.
 
@@ -84,13 +86,16 @@ def get_distance_expansion(name: str) -> type[DistanceExpansion]:
     >>> get_distance_expansion("Bessel")
     <class 'graph_pes.models.components.distances.Bessel'>
     """
+    if isinstance(thing, type) and issubclass(thing, DistanceExpansion):
+        return thing
+
     try:
-        klass = getattr(sys.modules[__name__], name)
+        klass = getattr(sys.modules[__name__], thing)
     except AttributeError:
-        raise ValueError(f"Unknown distance expansion type: {name}") from None
+        raise ValueError(f"Unknown distance expansion type: {thing}") from None
 
     if not isinstance(klass, type) or not issubclass(klass, DistanceExpansion):
-        raise ValueError(f"{name} is not a DistanceExpansion") from None
+        raise ValueError(f"{thing} is not a DistanceExpansion") from None
 
     return klass
 
@@ -356,7 +361,7 @@ class ExponentialRBF(DistanceExpansion):
         return torch.exp(-self.beta * offsets**2)
 
 
-class Envelope(torch.torch.nn.Module):
+class Envelope(torch.nn.Module):
     """
     Any envelope function, :math:`E(r)`, for smoothing potentials
     must implement a forward method that takes in a tensor of distances

--- a/src/graph_pes/models/tensornet.py
+++ b/src/graph_pes/models/tensornet.py
@@ -388,7 +388,7 @@ class ScalarOutput(nn.Module):
         norm_S = frobenius_norm(S)
 
         X = torch.cat((norm_I, norm_A, norm_S), dim=-1)  # (N, 3C)
-        # X = self.layer_norm(X)
+        X = self.layer_norm(X)
         return self.mlp(X)  # (N, 1)
 
 

--- a/src/graph_pes/models/tensornet.py
+++ b/src/graph_pes/models/tensornet.py
@@ -388,7 +388,7 @@ class ScalarOutput(nn.Module):
         norm_S = frobenius_norm(S)
 
         X = torch.cat((norm_I, norm_A, norm_S), dim=-1)  # (N, 3C)
-        X = self.layer_norm(X)
+        # X = self.layer_norm(X)
         return self.mlp(X)  # (N, 1)
 
 

--- a/src/graph_pes/models/tensornet.py
+++ b/src/graph_pes/models/tensornet.py
@@ -24,6 +24,7 @@ from graph_pes.utils.nn import (
 
 from .components.distances import (
     CosineEnvelope,
+    DistanceExpansion,
     ExponentialRBF,
     get_distance_expansion,
 )
@@ -63,7 +64,7 @@ class TensorNet(GraphPESModel):
         The number of interaction layers to use for the model.
     direct_force_predictions
         Whether to predict forces directly. If ``True``, the model will
-        the model will generate force predictions by passing the final
+        generate force predictions by passing the final
         layer's node embeddings through a
         :class:`~graph_pes.models.tensornet.VectorOutput` read out.
         Otherwise, ``graph-pes`` automatically infers the forces as the
@@ -88,7 +89,7 @@ class TensorNet(GraphPESModel):
         self,
         cutoff: float = DEFAULT_CUTOFF,
         radial_features: int = 32,
-        radial_expansion: str = "ExponentialRBF",
+        radial_expansion: str | type[DistanceExpansion] = ExponentialRBF,
         channels: int = 32,
         layers: int = 2,
         direct_force_predictions: bool = False,
@@ -123,8 +124,7 @@ class TensorNet(GraphPESModel):
         X = self.embedding(graph)  # (N, C, 3, 3)
 
         for interaction in self.interactions:
-            dX = interaction(X, graph)  # (N, C, 3, 3)
-            X = X + dX  # residual connection
+            X = interaction(X, graph)  # (N, C, 3, 3)
 
         local_energies = self.energy_read_out(X).squeeze()
         local_energies = self.scaler(local_energies, graph)
@@ -187,7 +187,7 @@ class EdgeEmbedding(nn.Module):
     def __init__(
         self,
         radial_features: int,
-        radial_expansion: str,
+        radial_expansion: str | type[DistanceExpansion],
         channels: int,
         cutoff: float,
     ):
@@ -251,7 +251,7 @@ class Embedding(nn.Module):
     def __init__(
         self,
         radial_features: int,
-        radial_expansion: str,
+        radial_expansion: str | type[DistanceExpansion],
         channels: int,
         cutoff: float,
     ):
@@ -358,7 +358,10 @@ class Interaction(nn.Module):
 
         # mix features again
         Y = self.W_I_post(I) + self.W_A_post(A) + self.W_S_post(S)
-        return Y + torch.matrix_power(Y, 2)  # (N, C, 3, 3)
+        dX = Y + torch.matrix_power(Y, 2)  # (N, C, 3, 3)
+
+        # residual connection: add dX to the normalised X
+        return X + dX
 
 
 class ScalarOutput(nn.Module):
@@ -372,6 +375,7 @@ class ScalarOutput(nn.Module):
 
     def __init__(self, channels: int):
         super().__init__()
+        self.layer_norm = nn.LayerNorm(3 * channels)
         self.mlp = MLP(
             layers=[3 * channels, 2 * channels, 1],
             activation=nn.SiLU(),
@@ -385,6 +389,7 @@ class ScalarOutput(nn.Module):
         norm_S = frobenius_norm(S)
 
         X = torch.cat((norm_I, norm_A, norm_S), dim=-1)  # (N, 3C)
+        X = self.layer_norm(X)
         return self.mlp(X)  # (N, 1)
 
 

--- a/tests/models/components/test_distances.py
+++ b/tests/models/components/test_distances.py
@@ -14,6 +14,7 @@ from graph_pes.models.components.distances import (
     GaussianSmearing,
     PolynomialEnvelope,
     SinExpansion,
+    get_distance_expansion,
 )
 
 _expansions = [Bessel, GaussianSmearing, SinExpansion, ExponentialRBF]
@@ -76,3 +77,17 @@ def test_envelopes(envelope: type[Envelope]):
     assert a > 0, "The envelope should be positive"
     assert b == 0, "The envelope should be zero at the cutoff"
     assert c == 0, "The envelope should be zero beyond the cutoff"
+
+
+def test_get_expansion():
+    assert (
+        get_distance_expansion("Bessel")
+        == get_distance_expansion(Bessel)
+        == Bessel
+    )
+
+    with pytest.raises(ValueError, match="Unknown distance expansion"):
+        get_distance_expansion("Unknown")
+
+    with pytest.raises(ValueError, match="is not a DistanceExpansion"):
+        get_distance_expansion("PolynomialEnvelope")

--- a/tests/models/test_equivariance.py
+++ b/tests/models/test_equivariance.py
@@ -11,7 +11,7 @@ from .. import helpers
 CUTOFF = 1.2  # bond length of methane is ~1.09 Å
 
 
-@helpers.parameterise_all_models(expected_elements=["H", "C"])
+@helpers.parameterise_all_models(expected_elements=["H", "C"], cutoff=CUTOFF)
 def test_equivariance(model: GraphPESModel):
     if isinstance(model, (PaiNN,)):
         pytest.skip(f"TODO: fix {model.__class__.__name__} equivariance")
@@ -25,10 +25,16 @@ def test_equivariance(model: GraphPESModel):
 
     # rotate the molecule
     new_methane = methane.copy()
-    shift = new_methane.positions.mean(axis=0)
+    shift = new_methane.positions[0]
     new_methane.positions = (new_methane.positions - shift).dot(R) + shift
     new_graph = AtomicGraph.from_ase(new_methane, cutoff=CUTOFF)
     new_predictions = model.get_all_PES_predictions(new_graph)
+
+    # pre-checks:
+    np.testing.assert_allclose(
+        np.linalg.norm(new_methane.positions - shift, axis=1),
+        np.linalg.norm(methane.positions - shift, axis=1),
+    )
 
     # now check:
     # 1. invariance of energy prediction
@@ -55,7 +61,7 @@ def test_equivariance(model: GraphPESModel):
         # auto-grad is not perfect, and we lose
         # precision, particularly with larger models
         # and default float32 dtype
-        atol=3e-2,
+        atol=3e-3,
         # some of the og predictions are 0: a large
         # relative error is not a problem here
         rtol=10,

--- a/tests/models/test_equivariance.py
+++ b/tests/models/test_equivariance.py
@@ -65,7 +65,7 @@ def test_equivariance(model: GraphPESModel):
     #    and of equal magnitude on the H atoms
     force_norms = new_predictions["forces"].norm(dim=-1)
     c_force = force_norms[new_graph.Z == 6]
-    assert c_force.item() == pytest.approx(0.0, abs=3e-3)
+    assert c_force.item() == pytest.approx(0.0, abs=3e-4)
 
     h_forces = force_norms[new_graph.Z == 1]
     assert h_forces.min().item() == pytest.approx(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -32,7 +32,7 @@ graphs = [
 
 
 def test_model():
-    model = LennardJones()
+    model = LennardJones(cutoff=3.0)
     model.pre_fit_all_components(graphs[:2])
 
     assert sum(p.numel() for p in model.parameters()) == 2
@@ -50,12 +50,12 @@ def test_isolated_atom():
     graph = AtomicGraph.from_ase(atom, cutoff=3)
     assert number_of_atoms(graph) == 1 and number_of_edges(graph) == 0
 
-    model = LennardJones()
+    model = LennardJones(cutoff=3.0)
     assert model.predict_energy(graph) == 0
 
 
 def test_pre_fit(caplog):
-    model = LennardJones()
+    model = LennardJones(cutoff=3.0)
     model.pre_fit_all_components(graphs)
 
     model.pre_fit_all_components(graphs)
@@ -66,7 +66,7 @@ def test_pre_fit(caplog):
     )
 
 
-@helpers.parameterise_model_classes(expected_elements=["Cu"])
+@helpers.parameterise_model_classes(expected_elements=["Cu"], cutoff=3.0)
 def test_model_serialisation(model_class: type[GraphPESModel], tmp_path):
     # 1. instantiate the model
     m1 = model_class()  # type: ignore
@@ -96,8 +96,8 @@ def test_cutoff_save_and_load():
 
 
 def test_addition():
-    lj = LennardJones()
-    m = Morse()
+    lj = LennardJones(cutoff=3.0)
+    m = Morse(cutoff=3.0)
 
     # test addition of two models
     addition_model = AdditionModel(lj=lj, morse=m)
@@ -117,7 +117,7 @@ def test_addition():
     )
 
 
-@helpers.parameterise_all_models(expected_elements=["Cu"])
+@helpers.parameterise_all_models(expected_elements=["Cu"], cutoff=3.0)
 def test_model_outputs(model: GraphPESModel):
     graph = graphs[0]
     assert has_cell(graph)

--- a/tests/models/test_predictions.py
+++ b/tests/models/test_predictions.py
@@ -29,7 +29,7 @@ def test_predictions():
         "local_energies": (2,),
     }
 
-    model = LennardJones()
+    model = LennardJones(cutoff=1.5)
 
     # no stress should be predicted for non-periodic systems
     predictions = model.get_all_PES_predictions(no_pbc)
@@ -66,7 +66,7 @@ def test_batched_prediction():
         "virial": (2, 3, 3),  # two structures
     }
 
-    predictions = LennardJones().get_all_PES_predictions(batch)
+    predictions = LennardJones(cutoff=1.5).get_all_PES_predictions(batch)
 
     for key in "energy", "forces", "stress", "virial":
         assert predictions[key].shape == expected_shapes[key]
@@ -77,7 +77,7 @@ def test_isolated_atom():
     graph = AtomicGraph.from_ase(atom, cutoff=1.5)
     assert number_of_edges(graph) == 0
 
-    predictions = LennardJones().get_all_PES_predictions(graph)
+    predictions = LennardJones(cutoff=1.5).get_all_PES_predictions(graph)
     assert torch.allclose(predictions["forces"], torch.zeros(1, 3))
 
 

--- a/tests/training/test_integration.py
+++ b/tests/training/test_integration.py
@@ -15,7 +15,7 @@ from graph_pes.training.util import VALIDATION_LOSS_KEY, LoggedProgressBar
 from .. import helpers
 
 
-@helpers.parameterise_all_models(expected_elements=["Cu"])
+@helpers.parameterise_all_models(expected_elements=["Cu"], cutoff=3)
 def test_integration(model: GraphPESModel):
     if len(list(model.parameters())) == 0:
         # nothing to train

--- a/tests/training/test_train_script.py
+++ b/tests/training/test_train_script.py
@@ -91,7 +91,8 @@ general:
     run_id: null
 wandb: null
 loss: +graph_pes.training.loss.PerAtomEnergyLoss()
-model: +LennardJones()    
+model: 
+    +LennardJones: {{cutoff: 3.0}}
 data:
     +graph_pes.data.load_atoms_dataset:
         id: {helpers.CU_STRUCTURES_FILE}


### PR DESCRIPTION
Changes:
- normalise the residual stream of `X` during message passing
- add a `LayerNorm` before the `ScalarReadout.mlp`