### PR TITLE
add check on cpu side to prevent kernel crash

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: tests
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2.1] - 2025-06-02
+
+Add explicit checking for unsupported elements in MACE interface.
+
 ## [0.1.2] - 2025-06-02
 
 Extracted a base class for all interface models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.2.1] - 2025-06-02
-
 Add explicit checking for unsupported elements in MACE interface.
 
 ## [0.1.2] - 2025-06-02

--- a/src/graph_pes/interfaces/_mace.py
+++ b/src/graph_pes/interfaces/_mace.py
@@ -26,6 +26,12 @@ class ZToOneHot(torch.nn.Module):
 
     def forward(self, Z: torch.Tensor) -> torch.Tensor:
         indices = self.z_to_index[Z]
+        if (indices < 0).any():
+            raise ValueError(
+                "ZToOneHot received an atomic number that is not in the model's "
+                f"element list: {Z[indices < 0]}. Please ensure the model was trained "
+                "with all elements present in the input graph."
+            )
         return torch.nn.functional.one_hot(indices, self.num_classes)
 
 

--- a/src/graph_pes/interfaces/_mace.py
+++ b/src/graph_pes/interfaces/_mace.py
@@ -28,9 +28,9 @@ class ZToOneHot(torch.nn.Module):
         indices = self.z_to_index[Z]
         if (indices < 0).any():
             raise ValueError(
-                "ZToOneHot received an atomic number that is not in the model's "
-                f"element list: {Z[indices < 0]}. Please ensure the model was trained "
-                "with all elements present in the input graph."
+                "ZToOneHot received an atomic number that is not in the model's"
+                f" element list: {Z[indices < 0]}. Please ensure the model was "
+                "trained with all elements present in the input graph."
             )
         return torch.nn.functional.one_hot(indices, self.num_classes)
 

--- a/src/graph_pes/interfaces/mace_test.py
+++ b/src/graph_pes/interfaces/mace_test.py
@@ -165,4 +165,4 @@ def test_go_mace_23():
 
 def test_z_to_onehot_raises_error():
     with pytest.raises(ValueError, match="Atomic number 0 is not supported"):
-        MACEWrapper(MACE_MODEL).z_to_onehot(torch.tensor([0, 1, 6, 8]))
+        MACEWrapper(MACE_MODEL).z_to_one_hot(torch.tensor([0, 1, 6, 8]))

--- a/src/graph_pes/interfaces/mace_test.py
+++ b/src/graph_pes/interfaces/mace_test.py
@@ -164,5 +164,5 @@ def test_go_mace_23():
     assert np.abs(calc.results["forces"][0]).max() < 1e-5
 
 def test_z_to_onehot_raises_error():
-    with pytest.raises(ValueError, match="Atomic number 0 is not supported"):
+    with pytest.raises(ValueError, match="ZToOneHot received an atomic number"):
         MACEWrapper(MACE_MODEL).z_to_one_hot(torch.tensor([0, 1, 6, 8]))

--- a/src/graph_pes/interfaces/mace_test.py
+++ b/src/graph_pes/interfaces/mace_test.py
@@ -162,3 +162,7 @@ def test_go_mace_23():
 
     calc.calculate(CH4, properties=["energy", "forces"])
     assert np.abs(calc.results["forces"][0]).max() < 1e-5
+
+def test_z_to_onehot_raises_error():
+    with pytest.raises(ValueError, match="Atomic number 0 is not supported"):
+        MACEWrapper(MACE_MODEL).z_to_onehot(torch.tensor([0, 1, 6, 8]))


### PR DESCRIPTION
ZToOneHot can cause kernel crashes if an unsupported element is run on the gpu. This PR fixes it by checking for unsupported elements explicitly and raising a value error.