### PR TITLE
Fix links in readme due to url change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <div align="center">
-    <a href="https://jla-gardner.github.io/graph-pes/">
+    <a href="https://vldgroup.github.io/graph-pes/">
         <img src="docs/source/_static/logo-text.svg" width="90%"/>
     </a>
 
 `graph-pes` is a framework built to accelerate the development of machine-learned potential energy surface (PES) models that act on graph representations of atomic structures.
 
-Links: [Google Colab Quickstart](https://colab.research.google.com/github/jla-gardner/graph-pes/blob/main/docs/source/quickstart/quickstart.ipynb) - [Documentation](https://jla-gardner.github.io/graph-pes/) - [PyPI](https://pypi.org/project/graph-pes/)
+Links: [Google Colab Quickstart](https://colab.research.google.com/github/vldgroup/graph-pes/blob/main/docs/source/quickstart/quickstart.ipynb) - [Documentation](https://vldgroup.github.io/graph-pes/) - [PyPI](https://pypi.org/project/graph-pes/)
 
 [![PyPI](https://img.shields.io/pypi/v/graph-pes)](https://pypi.org/project/graph-pes/)
 [![Conda-forge](https://img.shields.io/conda/vn/conda-forge/graph-pes.svg)](https://github.com/conda-forge/graph-pes-feedstock)
-[![Tests](https://github.com/jla-gardner/graph-pes/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/jla-gardner/graph-pes/actions/workflows/tests.yaml)
-[![codecov](https://codecov.io/gh/jla-gardner/graph-pes/branch/main/graph/badge.svg)](https://codecov.io/gh/jla-gardner/graph-pes)
-[![GitHub last commit](https://img.shields.io/github/last-commit/jla-gardner/load-atoms)]()
+[![Tests](https://github.com/vldgroup/graph-pes/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/vldgroup/graph-pes/actions/workflows/tests.yaml)
+[![codecov](https://codecov.io/gh/vldgroup/graph-pes/branch/main/graph/badge.svg)](https://codecov.io/gh/vldgroup/graph-pes)
+[![GitHub last commit](https://img.shields.io/github/last-commit/vldgroup/graph-pes)]()
 
 </div>
 
@@ -26,12 +26,12 @@ As a researcher wanting to work on MLIP methodology, `graph-pes` makes implement
 
 ## Features
 
-- Experiment with new model architectures by inheriting from our `GraphPESModel` [base class](https://jla-gardner.github.io/graph-pes/models/root.html).
-- [Train your own](https://jla-gardner.github.io/graph-pes/quickstart/implement-a-model.html) or existing model architectures (e.g., [SchNet](https://jla-gardner.github.io/graph-pes/models/many-body/schnet.html), [NequIP](https://jla-gardner.github.io/graph-pes/models/many-body/nequip.html), [PaiNN](https://jla-gardner.github.io/graph-pes/models/many-body/pinn.html), [MACE](https://jla-gardner.github.io/graph-pes/models/many-body/mace.html), [TensorNet](https://jla-gardner.github.io/graph-pes/models/many-body/tensornet.html), [OrB](https://jla-gardner.github.io/graph-pes/models/many-body/orb.html) etc.).
-- Use and fine-tune foundation models via a unified interface: [MACE-MP0](https://jla-gardner.github.io/graph-pes/interfaces/mace.html), [MACE-OFF](https://jla-gardner.github.io/graph-pes/interfaces/mace.html), [MatterSim](https://jla-gardner.github.io/graph-pes/interfaces/mattersim.html), [GO-MACE](https://jla-gardner.github.io/graph-pes/interfaces/mace.html), [Egret](https://jla-gardner.github.io/graph-pes/interfaces/mace.html#graph_pes.interfaces.egret) and [Orb v2/3](https://jla-gardner.github.io/graph-pes/interfaces/orb.html).
-- Easily configure distributed training, learning rate scheduling, weights and biases logging, and other features using our `graph-pes-train` [command line interface](https://jla-gardner.github.io/graph-pes/cli/graph-pes-train/root.html).
-- Use our data-loading pipeline within your [own training loop](https://jla-gardner.github.io/graph-pes/quickstart/custom-training-loop.html).
-- Run molecular dynamics simulations with any `GraphPESModel` using [torch-sim](https://jla-gardner.github.io/graph-pes/tools/torch-sim.html), [LAMMPS](https://jla-gardner.github.io/graph-pes/tools/lammps.html) or [ASE](https://jla-gardner.github.io/graph-pes/tools/ase.html)
+- Experiment with new model architectures by inheriting from our `GraphPESModel` [base class](https://vldgroup.github.io/graph-pes/models/root.html).
+- [Train your own](https://vldgroup.github.io/graph-pes/quickstart/implement-a-model.html) or existing model architectures (e.g., [SchNet](https://vldgroup.github.io/graph-pes/models/many-body/schnet.html), [NequIP](https://vldgroup.github.io/graph-pes/models/many-body/nequip.html), [PaiNN](https://vldgroup.github.io/graph-pes/models/many-body/painn.html), [MACE](https://vldgroup.github.io/graph-pes/models/many-body/mace.html), [TensorNet](https://vldgroup.github.io/graph-pes/models/many-body/tensornet.html), [OrB](https://vldgroup.github.io/graph-pes/models/many-body/orb.html) etc.).
+- Use and fine-tune foundation models via a unified interface: [MACE-MP0](https://vldgroup.github.io/graph-pes/interfaces/mace.html), [MACE-OFF](https://vldgroup.github.io/graph-pes/interfaces/mace.html), [MatterSim](https://vldgroup.github.io/graph-pes/interfaces/mattersim.html), [GO-MACE](https://vldgroup.github.io/graph-pes/interfaces/mace.html), [Egret](https://vldgroup.github.io/graph-pes/interfaces/mace.html#graph_pes.interfaces.egret) and [Orb v2/3](https://vldgroup.github.io/graph-pes/interfaces/orb.html).
+- Easily configure distributed training, learning rate scheduling, weights and biases logging, and other features using our `graph-pes-train` [command line interface](https://vldgroup.github.io/graph-pes/cli/graph-pes-train/root.html).
+- Use our data-loading pipeline within your [own training loop](https://vldgroup.github.io/graph-pes/quickstart/custom-training-loop.html).
+- Run molecular dynamics simulations with any `GraphPESModel` using [torch-sim](https://vldgroup.github.io/graph-pes/tools/torch-sim.html), [LAMMPS](https://vldgroup.github.io/graph-pes/tools/lammps.html) or [ASE](https://vldgroup.github.io/graph-pes/tools/ase.html)
 
 ## Quickstart
 
@@ -41,12 +41,12 @@ wget https://tinyurl.com/graph-pes-minimal-config -O config.yaml
 graph-pes-train config.yaml
 ```
 
-Alternatively, for a 0-install quickstart experience, please see [this Google Colab](https://colab.research.google.com/github/jla-gardner/graph-pes/blob/main/docs/source/quickstart/quickstart.ipynb), which you can also find in our [documentation](https://jla-gardner.github.io/graph-pes/quickstart/quickstart.html).
+Alternatively, for a 0-install quickstart experience, please see [this Google Colab](https://colab.research.google.com/github/vldgroup/graph-pes/blob/main/docs/source/quickstart/quickstart.ipynb), which you can also find in our [documentation](https://vldgroup.github.io/graph-pes/quickstart/quickstart.html).
 
 
 ## Contributing
 
-Contributions are welcome! If you find any issues or have suggestions for new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/jla-gardner/graph-pes). 
+Contributions are welcome! If you find any issues or have suggestions for new features, please open an issue or submit a pull request on the [GitHub repository](https://github.com/vldgroup/graph-pes). 
 We use `uv` to manage dependencies and run commands. Install it [here](https://docs.astral.sh/uv/), and sync the dependencies using `uv sync --all-extras`.
 
 Once you have made your changes, you can:

--- a/docs/source/tools/torch-sim.ipynb
+++ b/docs/source/tools/torch-sim.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# `torch-sim`\n",
     "\n",
-    "[torch-sim](https://radical-ai.github.io/torch-sim/index.html) is a tool for running (batched) molecular dynamics and structure optimisations in a GPU-accelerated manner.\n",
+    "[torch-sim](https://torchsim.github.io/torch-sim/index.html) is a tool for running (batched) molecular dynamics and structure optimisations in a GPU-accelerated manner.\n",
     "\n",
     "You can use **any** model from `graph-pes` with `torch-sim`! Doing this is extremely straightforward, as this notebook hopes to demonstrate. \n",
     "One caveat is that `torch-sim` expects all models to return energies and stresses in units of `eV` and forces in units of `eV/Å`. If you have a model that was trained in a different unit system, you will need to wrap it in a [graph_pes.models.UnitConverter](https://jla-gardner.github.io/graph-pes/models/root.html#unit-conversion) object so that it can be used in `torch-sim`.\n",
@@ -5771,7 +5771,7 @@
    "metadata": {},
    "source": [
     "You can also express a `(3, 3)` shaped `torch.Tensor` as an anisotropic external pressure.\n",
-    "See the `torch-sim` [docs](https://radical-ai.github.io/torch-sim/index.html) for more details.\n"
+    "See the `torch-sim` [docs](https://torchsim.github.io/torch-sim/index.html) for more details.\n"
    ]
   },
   {

--- a/src/graph_pes/graph_pes_model.py
+++ b/src/graph_pes/graph_pes_model.py
@@ -410,7 +410,7 @@ class GraphPESModel(GraphPropertyModel):
     ):
         """
         Return a model suitable for use with the
-        `torch_sim <https://github.com/Radical-AI/torch-sim>`__ package.
+        `torch_sim <https://github.com/TorchSim/torch-sim>`__ package.
 
         Internally, we set this model to evaluation mode, and wrap it in a
         class that is suitable for use with the ``torch_sim`` package.


### PR DESCRIPTION
This PR updates the readme for broken url.
Lychee did not find any other broker url, although there were some old torchsim url.