### PR TITLE
Move TorchSim wrapper upstream

### DIFF
--- a/src/graph_pes/graph_pes_model.py
+++ b/src/graph_pes/graph_pes_model.py
@@ -410,7 +410,7 @@ class GraphPESModel(GraphPropertyModel):
     ):
         """
         Return a model suitable for use with the
-        `torch_sim <https://github.com/Radical-AI/torch-sim>`__ package.
+        `torch_sim <https://github.com/TorchSim/torch-sim>`__ package.
 
         Internally, we set this model to evaluation mode, and wrap it in a
         class that is suitable for use with the ``torch_sim`` package.
@@ -437,7 +437,7 @@ class GraphPESModel(GraphPropertyModel):
                 "torch_sim is not installed. Please install it using "
                 "pip install torch-sim-atomistic"
             )
-        from torch_sim.models.graphpes import GraphPESWrapper
+        from graph_pes.torch_sim import GraphPESWrapper
 
         return GraphPESWrapper(
             self.eval(),

--- a/src/graph_pes/torch_sim.py
+++ b/src/graph_pes/torch_sim.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import traceback
+import warnings
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from graph_pes import AtomicGraph, GraphPESModel
+from graph_pes.atomic_graph import PropertyKey
+from graph_pes.models import load_model
+
+
+try:
+    from torch_sim.models.interface import ModelInterface
+    from torch_sim.neighbors import torchsim_nl
+    from torch_sim.state import SimState
+
+except ImportError as exc:
+    _torch_sim_import_error = exc
+    warnings.warn(
+        f"torch-sim import failed: {traceback.format_exc()}",
+        stacklevel=2,
+    )
+
+    class GraphPESWrapper(torch.nn.Module):
+        """Placeholder raised when torch-sim is unavailable."""
+
+        def __init__(
+            self,
+            err: ImportError = _torch_sim_import_error,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> None:
+            super().__init__()
+            raise err
+
+        def forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise NotImplementedError
+
+else:
+
+    def _state_to_atomic_graph(state: SimState, cutoff: torch.Tensor) -> AtomicGraph:
+        # graph-pes models internally trim the neighbor list to the model cutoff.
+        # Bump it slightly here to avoid exact-cutoff inclusion edge cases.
+        nl, _system_mapping, shifts = torchsim_nl(
+            state.positions,
+            state.row_vector_cell,
+            state.pbc,
+            cutoff + 1e-5,
+            state.system_idx,
+        )
+        n_atoms_per_system = torch.bincount(state.system_idx)
+        ptr = torch.zeros(state.n_systems + 1, dtype=torch.long, device=state.device)
+        ptr[1:] = n_atoms_per_system.cumsum(dim=0)
+        n_sys = state.n_systems
+        total_charge = torch.zeros(n_sys, device=state.device)
+        total_spin = torch.zeros(n_sys, device=state.device)
+        return AtomicGraph(
+            Z=state.atomic_numbers.long(),
+            R=state.positions,
+            cell=state.row_vector_cell,
+            neighbour_list=nl.long(),
+            neighbour_cell_offsets=shifts,
+            properties={},
+            cutoff=cutoff.item(),
+            other={
+                "total_charge": total_charge,
+                "total_spin": total_spin,
+            },
+            batch=state.system_idx,
+            ptr=ptr,
+        )
+
+    class GraphPESWrapper(ModelInterface):
+        """Wrap a GraphPES model for use with torch-sim."""
+
+        def __init__(
+            self,
+            model: GraphPESModel | str | Path,
+            device: torch.device | None = None,
+            dtype: torch.dtype = torch.float64,
+            *,
+            compute_forces: bool = True,
+            compute_stress: bool = True,
+        ) -> None:
+            super().__init__()
+            self._device = device or torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu"
+            )
+            self._dtype = dtype
+
+            _model = model if isinstance(model, GraphPESModel) else load_model(model)
+            self._gp_model = _model.to(device=self.device, dtype=self.dtype)
+
+            self._compute_forces = compute_forces
+            self._compute_stress = compute_stress
+
+            self._properties: list[PropertyKey] = ["energy"]
+            if self.compute_forces:
+                self._properties.append("forces")
+            if self.compute_stress:
+                self._properties.append("stress")
+
+            cutoff_val = self._gp_model.cutoff
+            if isinstance(cutoff_val, torch.Tensor) and cutoff_val.item() < 0.5:
+                self._memory_scales_with = "n_atoms"
+
+        def forward(
+            self, state: SimState, **_kwargs: object
+        ) -> dict[str, torch.Tensor]:
+            cutoff = self._gp_model.cutoff
+            if not isinstance(cutoff, torch.Tensor):
+                raise TypeError("GraphPES model cutoff must be a tensor")
+
+            atomic_graph = _state_to_atomic_graph(state, cutoff)
+            preds = self._gp_model.predict(atomic_graph, self._properties)
+            return {k: v.detach() for k, v in preds.items()}
+
+
+__all__ = ["GraphPESWrapper"]

--- a/src/graph_pes/torch_sim.py
+++ b/src/graph_pes/torch_sim.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import traceback
-import warnings
 from pathlib import Path
 from typing import Any
 
 import torch
 
-from graph_pes import AtomicGraph, GraphPESModel
-from graph_pes.atomic_graph import PropertyKey
-from graph_pes.models import load_model
+from graph_pes.atomic_graph import AtomicGraph, PropertyKey
+from graph_pes.graph_pes_model import GraphPESModel
 
 
 try:
@@ -19,10 +16,6 @@ try:
 
 except ImportError as exc:
     _torch_sim_import_error = exc
-    warnings.warn(
-        f"torch-sim import failed: {traceback.format_exc()}",
-        stacklevel=2,
-    )
 
     class GraphPESWrapper(torch.nn.Module):
         """Placeholder raised when torch-sim is unavailable."""
@@ -44,7 +37,7 @@ else:
     def _state_to_atomic_graph(state: SimState, cutoff: torch.Tensor) -> AtomicGraph:
         # graph-pes models internally trim the neighbor list to the model cutoff.
         # Bump it slightly here to avoid exact-cutoff inclusion edge cases.
-        nl, _system_mapping, shifts = torchsim_nl(
+        neighbour_list, _system_mapping, neighbour_cell_offsets = torchsim_nl(
             state.positions,
             state.row_vector_cell,
             state.pbc,
@@ -54,15 +47,17 @@ else:
         n_atoms_per_system = torch.bincount(state.system_idx)
         ptr = torch.zeros(state.n_systems + 1, dtype=torch.long, device=state.device)
         ptr[1:] = n_atoms_per_system.cumsum(dim=0)
-        n_sys = state.n_systems
-        total_charge = torch.zeros(n_sys, device=state.device)
-        total_spin = torch.zeros(n_sys, device=state.device)
+        n_systems = state.n_systems
+        # TorchSim does not track per-system charge or spin, but AtomicGraph
+        # reserves these slots for downstream interfaces that may expect them.
+        total_charge = torch.zeros(n_systems, device=state.device)
+        total_spin = torch.zeros(n_systems, device=state.device)
         return AtomicGraph(
             Z=state.atomic_numbers.long(),
             R=state.positions,
             cell=state.row_vector_cell,
-            neighbour_list=nl.long(),
-            neighbour_cell_offsets=shifts,
+            neighbour_list=neighbour_list.long(),
+            neighbour_cell_offsets=neighbour_cell_offsets,
             properties={},
             cutoff=cutoff.item(),
             other={
@@ -91,7 +86,12 @@ else:
             )
             self._dtype = dtype
 
-            _model = model if isinstance(model, GraphPESModel) else load_model(model)
+            if isinstance(model, GraphPESModel):
+                _model = model
+            else:
+                from graph_pes.models import load_model
+
+                _model = load_model(model)
             self._gp_model = _model.to(device=self.device, dtype=self.dtype)
 
             self._compute_forces = compute_forces

--- a/tests/test_torch_sim.py
+++ b/tests/test_torch_sim.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from ase.build import molecule
 
+from graph_pes.atomic_graph import AtomicGraph
 from graph_pes.models import SchNet
 
 
@@ -17,6 +18,7 @@ def test_torch_sim_model_matches_direct_wrapper():
     atoms.center(vacuum=10.0)
 
     model = SchNet(cutoff=5.5)
+    graph = AtomicGraph.from_ase(atoms, cutoff=5.5)
     direct_wrapper = GraphPESWrapper(
         model,
         device=DEVICE,
@@ -37,3 +39,12 @@ def test_torch_sim_model_matches_direct_wrapper():
     assert direct_output.keys() == method_output.keys()
     for key in direct_output:
         torch.testing.assert_close(direct_output[key], method_output[key])
+
+    torch.testing.assert_close(
+        method_output["energy"].cpu(),
+        model.predict_energy(graph).reshape(1).cpu(),
+    )
+    torch.testing.assert_close(
+        method_output["forces"].cpu(),
+        model.predict_forces(graph).cpu(),
+    )

--- a/tests/test_torch_sim.py
+++ b/tests/test_torch_sim.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+from ase.build import molecule
+
+from graph_pes.models import SchNet
+
+
+torch_sim = pytest.importorskip("torch_sim")
+from graph_pes.torch_sim import GraphPESWrapper
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DTYPE = torch.float32
+
+
+def test_torch_sim_model_matches_direct_wrapper():
+    atoms = molecule("H2O")
+    atoms.center(vacuum=10.0)
+
+    model = SchNet(cutoff=5.5)
+    direct_wrapper = GraphPESWrapper(
+        model,
+        device=DEVICE,
+        dtype=DTYPE,
+        compute_stress=False,
+    )
+    method_wrapper = model.torch_sim_model(
+        device=DEVICE,
+        dtype=DTYPE,
+        compute_stress=False,
+    )
+
+    state = torch_sim.io.atoms_to_state([atoms], DEVICE, DTYPE)
+    direct_output = direct_wrapper(state)
+    method_output = method_wrapper(state)
+
+    assert isinstance(method_wrapper, GraphPESWrapper)
+    assert direct_output.keys() == method_output.keys()
+    for key in direct_output:
+        torch.testing.assert_close(direct_output[key], method_output[key])


### PR DESCRIPTION
This is the `graph-pes` side of TorchSim/torch-sim#525.

Summary
  - move the TorchSim GraphPES wrapper implementation into `graph-pes`
  - update `GraphPESModel.torch_sim_model()` to use the upstream wrapper
  - add a regression test covering the upstream TorchSim integration path


Validation
  - `pytest tests/`
  - result: `272 passed, 1 skipped`