### PR TITLE
Move TorchSim wrapper into interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Moved the TorchSim wrapper implementation to `graph_pes.interfaces._torch_sim` and renamed the primary wrapper class to `TorchSimWrapper`.
+
 ## [1.0.0] - 2026-05-07
 Fix Ruff formatting issues in graph_pes/torch_sim.py
 

--- a/src/graph_pes/graph_pes_model.py
+++ b/src/graph_pes/graph_pes_model.py
@@ -437,9 +437,9 @@ class GraphPESModel(GraphPropertyModel):
                 "torch_sim is not installed. Please install it using "
                 "pip install torch-sim-atomistic"
             )
-        from graph_pes.torch_sim import GraphPESWrapper
+        from graph_pes.interfaces._torch_sim import TorchSimWrapper
 
-        return GraphPESWrapper(
+        return TorchSimWrapper(
             self.eval(),
             device=device,
             dtype=dtype,

--- a/src/graph_pes/interfaces/_torch_sim.py
+++ b/src/graph_pes/interfaces/_torch_sim.py
@@ -16,7 +16,7 @@ try:
 except ImportError as exc:
     _torch_sim_import_error = exc
 
-    class GraphPESWrapper(torch.nn.Module):
+    class TorchSimWrapper(torch.nn.Module):
         """Placeholder raised when torch-sim is unavailable."""
 
         def __init__(
@@ -34,8 +34,8 @@ except ImportError as exc:
 else:
 
     def _state_to_atomic_graph(
-            state: SimState, 
-            cutoff: torch.Tensor) -> AtomicGraph:
+        state: SimState, cutoff: torch.Tensor
+    ) -> AtomicGraph:
         # graph-pes models internally trim the neighbor list to the model cutoff
         # Bump it slightly here to avoid exact-cutoff inclusion edge cases.
         neighbour_list, _system_mapping, neighbour_cell_offsets = torchsim_nl(
@@ -46,9 +46,9 @@ else:
             state.system_idx,
         )
         n_atoms_per_system = torch.bincount(state.system_idx)
-        ptr = torch.zeros(state.n_systems + 1, 
-                          dtype=torch.long, 
-                          device=state.device)
+        ptr = torch.zeros(
+            state.n_systems + 1, dtype=torch.long, device=state.device
+        )
         ptr[1:] = n_atoms_per_system.cumsum(dim=0)
         n_systems = state.n_systems
         # TorchSim does not track per-system charge or spin, but AtomicGraph
@@ -71,7 +71,7 @@ else:
             ptr=ptr,
         )
 
-    class GraphPESWrapper(ModelInterface):
+    class TorchSimWrapper(ModelInterface):
         """Wrap a GraphPES model for use with torch-sim."""
 
         def __init__(
@@ -122,4 +122,6 @@ else:
             return {k: v.detach() for k, v in preds.items()}
 
 
-__all__ = ["GraphPESWrapper"]
+GraphPESWrapper = TorchSimWrapper
+
+__all__ = ["TorchSimWrapper", "GraphPESWrapper"]

--- a/tests/test_torch_sim.py
+++ b/tests/test_torch_sim.py
@@ -5,9 +5,8 @@ from ase.build import molecule
 from graph_pes.atomic_graph import AtomicGraph
 from graph_pes.models import SchNet
 
-
 torch_sim = pytest.importorskip("torch_sim")
-from graph_pes.torch_sim import GraphPESWrapper
+from graph_pes.interfaces._torch_sim import GraphPESWrapper, TorchSimWrapper
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 DTYPE = torch.float32
@@ -19,7 +18,7 @@ def test_torch_sim_model_matches_direct_wrapper():
 
     model = SchNet(cutoff=5.5)
     graph = AtomicGraph.from_ase(atoms, cutoff=5.5)
-    direct_wrapper = GraphPESWrapper(
+    direct_wrapper = TorchSimWrapper(
         model,
         device=DEVICE,
         dtype=DTYPE,
@@ -35,7 +34,8 @@ def test_torch_sim_model_matches_direct_wrapper():
     direct_output = direct_wrapper(state)
     method_output = method_wrapper(state)
 
-    assert isinstance(method_wrapper, GraphPESWrapper)
+    assert GraphPESWrapper is TorchSimWrapper
+    assert isinstance(method_wrapper, TorchSimWrapper)
     assert direct_output.keys() == method_output.keys()
     for key in direct_output:
         torch.testing.assert_close(direct_output[key], method_output[key])


### PR DESCRIPTION
This PR does a small cleanup following the recent TorchSim adapter migration.

Changes:
 – Move the TorchSim wrapper from `graph_pes/torch_sim.py` to `graph_pes/interfaces/_torch_sim.py`.
 – Rename the wrapper class from `GraphPESWrapper` to `TorchSimWrapper`
 – Update the `GraphPESModel.torch_sim_model()` and the TorchSim test to use `TorchSimWrapper`.